### PR TITLE
reverted default cidr back to /8

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "vpnclient_ip" {
 variable "vpc_cidr" {
   type        = string
   description = "CIDR for the private VPC the VPN is connected to."
-  default     = "10.0.0.0/12"
+  default     = "10.0.0.0/8"
 }
 
 variable "dns_cidr" {


### PR DESCRIPTION
### Description

Updated default cidr to /8 so it is compatible with reference architectures, without any other changes.