### PR TITLE
Add string suffix to secret group and certificate secret names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Client 2 Site VPN
 
-This is a terraform module that will provision a client-to-site VPN on IBM Cloud.  _Note: This is a beta offering that is not supported by the IBM cloud Terraform provider yet, so it is implemented using a `local-exec` provisioner with a bash script to handle resource creation and configuration.
+This is a terraform module that will provision a client-to-site VPN on IBM Cloud.  _Note: This is an offering that is not supported by the IBM cloud Terraform provider yet, so it is implemented using a `local-exec` provisioner with a bash script to handle resource creation and configuration.
 
-This module will: 
+This module will:
 
 - Download necessary CLI dependencies (`jq`)
 - Create a group in a secrets manager instance
-- Create a server and a client certificate and import them into the secrets manager group
+- Create a server and a client certificate and import them into the secrets manager group, tagging secrets by the VPN server name
 - Update the ACL for the VPC subnet to allow for VPN ingress & egress
 - Create a security group and security group rules for the VPN server instance
 - Provision a VPN server
@@ -15,20 +15,22 @@ This module will:
 ## Software dependencies
 
 Dependencies:
+
 - [CLIs](https://github.com/cloud-native-toolkit/terraform-util-clis)
-- [Resource Group](https://github.com/cloud-native-toolkit/terraform-ibm-resource-group)
-- [Certificate Manager](https://github.com/cloud-native-toolkit/terraform-ibm-cert-manager)
-- [VPC Subnet](https://github.com/cloud-native-toolkit/terraform-ibm-vpc-subnets)
+- [Resource Group](https://github.com/terraform-ibm-modules/terraform-ibm-toolkit-resource-group)
+- [Secrets Manager](https://github.com/terraform-ibm-modules/terraform-ibm-toolkit-cert-manager)
+- [VPC Subnet](https://github.com/terraform-ibm-modules/terraform-ibm-toolkit-vpc-subnets)
 
 ### Command-line tools
 
-- `terraform` - v1.2.8
+- `terraform` >= v1.2.8
 - `jq`
 - `ibmcloud`
 
 ### Terraform providers
 
-None
+- `ibm-cloud/ibm`
+- `hashicorp/random`
 
 ## Example usage
 
@@ -40,9 +42,8 @@ module "vpn_module" {
   region                = var.region
   ibmcloud_api_key      = var.ibmcloud_api_key
   resource_label        = "client2site"
-  secrets_manager_name  = module.secrets-manager.name
+  secrets_manager_name  = module.secrets-manager.guid
   vpc_id                = module.subnets.vpc_id
   subnet_ids            = module.subnets.ids
 }
 ```
-

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ locals {
   prefix_name     = var.name_prefix != "" ? var.name_prefix : var.resource_group_name
   name            = lower(replace("${local.prefix_name}-vpn-${var.resource_label}", "_", "-"))
   vpn_profile     = "${path.root}/${local.name}.ovpn"
+  sm_region       = var.sm_region != "" ? var.sm_region : var.region
 }
 
 resource "random_string" "suffix" {
@@ -87,7 +88,7 @@ resource "null_resource" "security_group" {
       bin_dir          = module.clis.bin_dir
       name             = local.sm_group_name
       description      = "VPN Certificates Group"
-      region           = var.region
+      region           = local.sm_region
       instance_id      = var.secrets_manager_guid
     }
 
@@ -129,7 +130,7 @@ data "external" "sm_group" {
     ibmcloud_api_key    = var.ibmcloud_api_key
     bin_dir             = module.clis.bin_dir
     group_name          = local.sm_group_name
-    region              = var.region   
+    region              = local.sm_region   
     instance_id         = var.secrets_manager_guid
   }
 }
@@ -146,7 +147,7 @@ resource "null_resource" "server_cert_secret" {
         bin_dir          = module.clis.bin_dir
         name             = local.server-secret-name
         description      = "VPN server certificate"
-        region           = var.region
+        region           = local.sm_region
         instance_id      = var.secrets_manager_guid
         group_id         = data.external.sm_group.result.group_id
         labels           = local.name
@@ -198,7 +199,7 @@ data "external" "server-secret" {
     ibmcloud_api_key    = var.ibmcloud_api_key
     bin_dir             = module.clis.bin_dir
     group_id            = data.external.sm_group.result.group_id
-    region              = var.region   
+    region              = local.sm_region   
     instance_id         = var.secrets_manager_guid
     name                = local.server-secret-name
   }  
@@ -211,7 +212,7 @@ resource "null_resource" "client_cert_secret" {
         bin_dir          = module.clis.bin_dir
         name             = local.client-secret-name
         description      = "VPN client certificate"
-        region           = var.region
+        region           = local.sm_region
         instance_id      = var.secrets_manager_guid
         group_id         = data.external.sm_group.result.group_id
         labels           = local.name
@@ -263,7 +264,7 @@ data "external" "client-secret" {
     ibmcloud_api_key    = var.ibmcloud_api_key
     bin_dir             = module.clis.bin_dir
     group_id            = data.external.sm_group.result.group_id
-    region              = var.region   
+    region              = local.sm_region   
     instance_id         = var.secrets_manager_guid
     name                = local.client-secret-name
   }  

--- a/scripts/import-certificate.sh
+++ b/scripts/import-certificate.sh
@@ -15,7 +15,7 @@ if [[ -z "${ACCOUNT_ID}" ]]; then
   exit 1
 fi
 
-DATA="{\"metadata\": {\"collection_type\": \"application/vnd.ibm.secrets-manager.secret+json\",\"collection_total\": 1 }, \"resources\": [ { \"name\": \"${NAME}\", \"description\": \"${DESCRIPTION}\", \"secret_group_id\": \"${GROUP_ID}\", \"labels\": [\"test\",\"eu-gb\"], \"certificate\": \"${CERT}\", \"private_key\": \"${PRIV_KEY}\", \"intermediate\": \"${CA_CERT}\" } ] }"
+DATA="{\"metadata\": {\"collection_type\": \"application/vnd.ibm.secrets-manager.secret+json\",\"collection_total\": 1 }, \"resources\": [ { \"name\": \"${NAME}\", \"description\": \"${DESCRIPTION}\", \"secret_group_id\": \"${GROUP_ID}\", \"labels\": [ \"${LABELS}\" ], \"certificate\": \"${CERT}\", \"private_key\": \"${PRIV_KEY}\", \"intermediate\": \"${CA_CERT}\" } ] }"
 
 BASE_URL="https://${INSTANCE_ID}.${REGION}.secrets-manager.appdomain.cloud"
 

--- a/test/stages/stage1-secrets-manager.tf
+++ b/test/stages/stage1-secrets-manager.tf
@@ -4,5 +4,5 @@ module "secrets-manager" {
   resource_group_name = module.resource_group.name
   region              = var.region
   private_endpoint    = false
-  trial               = true
+  trial               = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "region" {
   description = "The IBM Cloud region where the resources will be provisioned."
 }
 
+variable "sm_region" {
+  type        = string
+  description = "The IBM Cloud region where the Service Manager resides if different from VPC and VPN server"
+  default     = ""
+}
+
 variable "resource_label" {                   
   type        = string                        
   description = "The label for the resource to which the vpe will be connected. Used as a tag and as part of the vpe name."

--- a/version.tf
+++ b/version.tf
@@ -6,5 +6,9 @@ terraform {
       source = "ibm-cloud/ibm"
       version = ">= 1.22.0"
     }
+    random = {
+      source = "hashicorp/random"
+      version = ">= 3.4.0"
+    }
   }
 }


### PR DESCRIPTION
### Description

This PR enhances the module to potentially support the use of a single Secrets Manager instance in an account by adding a string suffix to the original hard-coded secret group and certificate secrets. It adds an optional variable that can be used to indicate that the target Secrets Manager instance is in a different region from the VPC that will include the VPN Server

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

fixes #30 

---

### Checklist for reviewers

- [x] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [x] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
